### PR TITLE
Fix a bug in cqtopencvviewergl.cpp

### DIFF
--- a/cqtopencvviewergl/cqtopencvviewergl.cpp
+++ b/cqtopencvviewergl/cqtopencvviewergl.cpp
@@ -113,7 +113,7 @@ bool CQtOpenCVViewerGl::showImage(const cv::Mat& image)
 {
     if (image.channels() == 3)
         cvtColor(image, mOrigImage, CV_BGR2RGBA);
-    else if (mOrigImage.channels() == 1)
+    else if (image.channels() == 1)
         cvtColor(image, mOrigImage, CV_GRAY2RGBA);
     else return false;
 


### PR DESCRIPTION
Row 116: “else if (**mOrigImage**.channels() == 1)” should be “else if (**image**.channels() == 1)”,  or it will cause a bug when you want to show a single channel image.
Many people have found this bug, but it is still here.
BTW, thanks to the author for the great tutorial.